### PR TITLE
added add/remove methods with emitting

### DIFF
--- a/component.json
+++ b/component.json
@@ -5,6 +5,7 @@
   "version": "0.0.1",
   "keywords": ["enumerable", "data", "model", "db"],
   "dependencies": {
+    "component/emitter": "*",
     "component/enumerable": "*"
   },
   "development": {},

--- a/index.js
+++ b/index.js
@@ -74,7 +74,8 @@ Collection.prototype.push = function(model){
 };
 
 /**
- * Remove `model` from the collection.
+ * Remove `model` from the collection, returning `true` when present,
+ * otherwise `false`.
  *
  * @param {Object} model
  * @api public

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ Collection.prototype.length = function(){
  * @api public
  */
 
+Collection.prototype.add =
 Collection.prototype.push = function(model){
   return this.models.push(model);
 };

--- a/index.js
+++ b/index.js
@@ -63,3 +63,16 @@ Collection.prototype.add =
 Collection.prototype.push = function(model){
   return this.models.push(model);
 };
+
+/**
+ * Remove `model` from the collection.
+ *
+ * @param {Object} model
+ * @api public
+ */
+
+Collection.prototype.remove = function(model){
+  var i = this.indexOf(model);
+  if (~i) this.models.splice(i, 1);
+  return !! ~i;
+};

--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@
  * Module dependencies.
  */
 
-var Enumerable = require('enumerable');
+var Emitter = require('emitter')
+  , Enumerable = require('enumerable');
 
 /**
  * Expose `Collection`.
@@ -21,6 +22,12 @@ module.exports = Collection;
 function Collection(models) {
   this.models = models || [];
 }
+
+/**
+ * Mixin emitter.
+ */
+
+Emitter(Collection.prototype);
 
 /**
  * Mixin enumerable.
@@ -61,7 +68,9 @@ Collection.prototype.length = function(){
 
 Collection.prototype.add =
 Collection.prototype.push = function(model){
-  return this.models.push(model);
+  var length = this.models.push(model);
+  this.emit('add', model);
+  return length;
 };
 
 /**
@@ -73,6 +82,9 @@ Collection.prototype.push = function(model){
 
 Collection.prototype.remove = function(model){
   var i = this.indexOf(model);
-  if (~i) this.models.splice(i, 1);
+  if (~i) {
+    this.models.splice(i, 1);
+    this.emit('remove', model);
+  }
   return !! ~i;
 };


### PR DESCRIPTION
a `remove` makes a lot of sense to me, in which case having the `add` alias is nicer imo. with `push` left for backwards compat.

and then i'd like to be able to listen to models being added/removed from collections.
